### PR TITLE
chore: ignore .idea/, .vscode/, *.iml — IDE local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ runtime/
 # Pandas orchestration runtime state (per-device, not for repo)
 .pandas_tg_offset
 .pandas_hold
+
+# IDE / editor
+.idea/
+.vscode/
+*.iml


### PR DESCRIPTION
## Summary

- `.idea/` (JetBrains), `.vscode/`, `*.iml` added to `.gitignore`
- These are per-developer IDE config files and should not be tracked

## Test plan

- [x] `git status` shows `.idea/` no longer listed as untracked after this change
- [x] `npm run release:audit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)