### PR TITLE
fix: execFileAsync declaration order in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,9 @@ async function start(): Promise<void> {
   }
 }
 
-void start();
-
 const execFileAsync = promisify(execFile);
+
+void start();
 
 async function runCommand(
   command: "backup-export" | "import-validate" | "acks-prune" | "task-heartbeat" | "pandas-heartbeat",


### PR DESCRIPTION
## Summary

- `execFileAsync` was declared after `void start()`, causing a `ReferenceError: Cannot access 'execFileAsync' before initialization` at runtime when `APP_COMMAND=pandas-heartbeat` was triggered
- Moved declaration above `void start()` to fix initialization order

## Test plan

- [ ] `APP_COMMAND=pandas-heartbeat node --import tsx src/index.ts` runs without error
- [ ] pandas-heartbeat auto-claims a ready task and writes to inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)